### PR TITLE
v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,61 +10,81 @@ Requires `bash`, `gcloud` and `python2.7.x` (required by `gcloud`); or just use 
 -  [gcloud sdk](https://cloud.google.com/sdk/install)
 
 ### Specs
--  Instance: n1-standard-8
--  Accelerator: nvidia-tesla-p4-vws
--  Boot: 50GB pd-ssd
--  Storage: 500GB pd-standard
--  Base image: latest from GCE's windows-2016 family
+-  8 vCPU (n1-standard-8)
+-  NVIDIA Tesla P4 (nvidia-tesla-p4-vws)
+-  50GB SSD (pd-ssd)
+-  500GB Storage (pd-standard)
+-  Windows Server 2016 (windows-2016)
 
 *Cloud responsibly. These scripts are provided as-is, with zero support. At the very least, create a new GCP project.*
 
-## Setup
+## One-time setup
 -  [Start Cloud Shell in a new project](https://cloud.google.com/shell/docs/starting-cloud-shell)
-    -  Alternatively, run `gcloud init` to authenticate and create a new project.
+
+   Alternatively, run `gcloud init`
+
 -  [Ensure billing is enabled](https://cloud.google.com/billing/docs/how-to/modify-project) for this new project.
+
 -  Clone this repository
        $ git clone "https://github.com/putty182/gcloudrig"
+
 -  Run `setup.sh`
         $ cd "gcloudrig"
         $ ./setup.sh
 
+-  If anything goes wrong during setup, start over with these commands
+        $ ./destroy.sh
+        $ gcloud init
+        $ ./setup.sh
 
 
-## Connecting to your instance
-- Run `./scale-up.sh` to start your instance.  Depending on what region you're using, this can take anywhere from 60 seconds to whenever a resources become available.
+## Starting your rig
+- Run `./scale-up.sh` to start your instance.
+
 - Run `./reset-windows-password.sh` to get the IP, Username and Password you'll need to RDP to your instance and start installing software.
-- Alternatively, visit [Compute Engine > VM Instances](https://console.cloud.google.com/compute/instances) to set a password and download an RDP file.  See [Creating Passwords for Windows Instances](https://cloud.google.com/compute/docs/instances/windows/creating-passwords-for-windows-instances) and [Connecting to Windows Instances](https://cloud.google.com/compute/docs/instances/connecting-to-instance#windows) for more info.
 
-## Stopping your instance
-- Run `./scale-down.sh` to shutdown your instance.  Once stopped, this will take 10~20 minutes to create a boot image and disk snapshot before deleting those volumes to keep costs down.  Read *Disk maintenance* below for more info.
+  Alternatively, visit [Compute Engine > VM Instances](https://console.cloud.google.com/compute/instances) to set a password and download an RDP file.  See [Creating Passwords for Windows Instances](https://cloud.google.com/compute/docs/instances/windows/creating-passwords-for-windows-instances) and [Connecting to Windows Instances](https://cloud.google.com/compute/docs/instances/connecting-to-instance#windows) for more info.
 
-## (Recommended) Install a bunch of things
+## Stopping your rig
+- Run `./scale-down.sh` to shutdown your instance.
+
+  Once stopped, it will take a few minutes to create a copy of both boot and games disks.  Read *Disk maintenance* below for more info.
+
+## Install a bunch of things (Recommended)
+Once you've started your rig, it will be empty.  There are no pre-installed software or drivers (...yet)
+
+Follow these steps to get a stable "gaming" setup:
+
 - Install [GRID® drivers for virtual workstations](https://cloud.google.com/compute/docs/gpus/add-gpus#installing_gridwzxhzdk37_drivers_for_virtual_workstations)
+
 - Install [Virtual Audio Cable](https://www.vb-audio.com/Cable/)
+
 - Setup [Autologon](https://docs.microsoft.com/en-au/sysinternals/downloads/autologon) to avoid a login screen at boot
+
 - Install [ZeroTier](https://zerotier.com/), create/join a network, and set it to run on boot by right-clicking it's icon in the system tray
+
 - Install [TightVNC Server](https://www.tightvnc.com/) and lock it down to zerotier's IP range (e.g. `allow 10.147.17.0-10.147.17.255`; `deny 0.0.0.0-255.255.255`).  Test a VNC connection using your instance's ZeroTier IP now.
+
 - Reboot to finish GPU driver installation.
+
 - Login with TightVNC, set display to "Show only on Monitor 2" and give it an appropriate screen resolution.  This will disable the primary 640x480 virtual screen, which can't be resized and gives Parsec headaches when games try to launch on it.
+
 - Attempt to change the volume; Windows should prompt that the Windows Sound service isn't running.  Start it.  Alternatviely, run `services.msc` and change it's startup options there.
+
 - Install [Parsec](https://parsecgaming.com/), save login details, and set it to run on boot by right-clicking it's icon in the system tray
+
 - Install game clients (e.g. Steam) and a game or two.
+
 - (Optional) Signup at [Duck DNS](https://www.duckdns.org/) and create a hostname for the private ZeroTier IP (NOT the public one).  If you really want a hostname for the dynamic public IP as well, create a secondary hostname and pick your favourite set of installation instructions.
+
 - (Optional) Edit `default-allow-rdp` firewall rule in Cloud Console, change it's `Targets` to `Specified target tags` and add a target tag of `rdp-server`, so only instances with the network tag `rdp-server` have public RDP ports.  If you really need to RDP into the public IP address, add this network tag to a running instance.
 
 ## Notes
-Once everything's setup, avoid using RDP since it'll disconnect your "physical" session on the virtual monitor - i.e. it'll show the windows lock screen, which upsets most streaming clients.  If you find yourself in this situation, connect using VNC to fix the issue or just use RDP anyway and restart the instance.
+Avoid using RDP since it'll disconnect your "physical" session on the virtual monitor.  Doing so will show the windows lock screen on the virtual monitor, which upsets most streaming clients.  If you find yourself in this situation, connect using VNC to fix the issue or just use RDP anyway and restart the instance.
 
 Whenever connecting to your instance, you should always use the ZeroTier IP. Only open up your instance's Public IP if that few extra milliseconds of software networking lag is worth foregoing basic network security.
 
 ## Travelling?
--  Change `REGION` in `./globals.sh` to the [GCP region with the lowest ping](http://www.gcping.com/).
--  Run `./scale-up.sh`
+gcloudrig keeps your rig as a boot image and disk snapshot, both of which are globally available in GCE.
 
-## Disk maintenance
-Disks are automatically imaged or snapshotted whenever you run `./scale-down.sh`, which avoids the need to pay for persistent storage when the instance isn't running.  However, to get the best bang-for-buck you should do the following whenever you delete a large amount of data from your games disk:
--  Run [`sdelete`](https://docs.microsoft.com/en-us/sysinternals/downloads/sdelete) to zero out free space on your games disk, e.g. `sdelete -z G:\`.
--  After you've run `scale-down.sh`, check your [Snapshot](https://console.cloud.google.com/compute/snapshots) usage.  Add in the `Labels` column to this page;  you can safely delete any image labelled `gcloud:true` *except* for the one labelled `latest:true`.
-
-## Starting over
--  Run `./destroy.sh` and answer yes to all prompts.  This might not delete everything;  check cloud console for any remaining resources.
+To run your rig in a different part of the world, just `./setup.sh` again and change your default region.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 A collection of bash scripts that use [Google's Cloud SDK](https://cloud.google.com/sdk/gcloud/) to create and maintain a cloud gaming instance, on the cheap.
 
-Requires `bash`, `gcloud` and `python2` (required by `gcloud`); or just use [Cloud Shell](https://cloud.google.com/shell/).
+Requires `bash`, `gcloud` and `python2.7.x` (required by `gcloud`); or just use [Cloud Shell](https://cloud.google.com/shell/).
+
+## Prerequisites
+-  bash
+-  python 2.7.x
+-  [gcloud sdk](https://cloud.google.com/sdk/install)
 
 ### Specs
 -  Instance: n1-standard-8
@@ -14,8 +19,16 @@ Requires `bash`, `gcloud` and `python2` (required by `gcloud`); or just use [Clo
 *Cloud responsibly. These scripts are provided as-is, with zero support. At the very least, create a new GCP project.*
 
 ## Setup
-- Edit `./globals.sh` and set `REGION` and `PROJECT_ID` variables.
-- Run `./setup.sh`.  This may take 20 minutes, but is only required once.
+-  [Start Cloud Shell in a new project](https://cloud.google.com/shell/docs/starting-cloud-shell)
+    -  Alternatively, run `gcloud init` to authenticate and create a new project.
+-  [Ensure billing is enabled](https://cloud.google.com/billing/docs/how-to/modify-project) for this new project.
+-  Clone this repository
+       $ git clone "https://github.com/putty182/gcloudrig"
+-  Run `setup.sh`
+        $ cd "gcloudrig"
+        $ ./setup.sh
+
+
 
 ## Connecting to your instance
 - Run `./scale-up.sh` to start your instance.  Depending on what region you're using, this can take anywhere from 60 seconds to whenever a resources become available.

--- a/destroy.sh
+++ b/destroy.sh
@@ -6,23 +6,17 @@ set -e
 # full path to script dir
 DIR="$( cd "$( dirname -- "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-# load globals 
+# load globals
 # shellcheck source=globals.sh
 source "$DIR/globals.sh"
+init_globals;
 
 # shut it down
-gcloudrig_stop || echo .
+gcloudrig_stop || echo -n
 
 # delete managed instance group
-gcloud compute instance-groups managed delete "$INSTANCEGROUP" --region "$REGION" --quiet || echo .
+gcloud compute instance-groups managed delete "$INSTANCEGROUP" --region "$REGION" --quiet || echo -n
 
 # delete instance templates
-gcloud compute instance-templates delete "$INSTANCETEMPLATE-base" --quiet || echo .
-gcloud compute instance-templates delete "$INSTANCETEMPLATE" --quiet || echo .
-
-# delete disks
-gcloud compute disks delete "$GAMESDISK" --zone "$ZONE" --quiet || echo .
-gcloud compute disks delete "$BOOTDISK" --zone "$ZONE" --quiet || echo .
-
-# delete image
-gcloud compute images delete $IMAGE --quiet || echo .
+gcloud compute instance-templates delete "$INSTANCETEMPLATE-base" --quiet || echo -n
+gcloud compute instance-templates delete "$INSTANCETEMPLATE" --quiet || echo -n

--- a/destroy.sh
+++ b/destroy.sh
@@ -9,7 +9,7 @@ DIR="$( cd "$( dirname -- "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 # load globals
 # shellcheck source=globals.sh
 source "$DIR/globals.sh"
-init_globals;
+init;
 
 # shut it down
 gcloudrig_stop || echo -n

--- a/destroy.sh
+++ b/destroy.sh
@@ -15,8 +15,21 @@ init_globals;
 gcloudrig_stop || echo -n
 
 # delete managed instance group
-gcloud compute instance-groups managed delete "$INSTANCEGROUP" --region "$REGION" --quiet || echo -n
+gcloud compute instance-groups managed delete "$INSTANCEGROUP" --region "$REGION" || echo -n
 
 # delete instance templates
-gcloud compute instance-templates delete "$INSTANCETEMPLATE-base" --quiet || echo -n
-gcloud compute instance-templates delete "$INSTANCETEMPLATE" --quiet || echo -n
+gcloud compute instance-templates delete "$INSTANCETEMPLATE" || echo -n
+
+# delete image
+gcloud compute images delete "$IMAGE" || echo -n
+
+# delete snapshots
+SNAPSHOTS=()
+mapfile -t SNAPSHOTS < <(gcloud compute snapshots list \
+  --format "value(name)" \
+--filter "labels.$GCRLABEL=true")
+
+# remove the "latest=true" label from all existing gcloudrig snapshots
+for SNAP in "${SNAPSHOTS[@]}"; do
+  gcloud compute snapshots delete "$SNAP"
+done

--- a/globals.sh
+++ b/globals.sh
@@ -56,10 +56,10 @@ function init {
 function init_setup {
 
   if [ -z "$(gcloud config configurations list --filter "name=(gcloudrig)" --format "value(name)" --quiet)" ]; then
-    gcloud config configurations create $CONFIGURATION --quiet
+    gcloud config configurations create "$CONFIGURATION" --quiet
   fi
 
-  gcloud config configurations activate $CONFIGURATION --quiet
+  gcloud config configurations activate "$CONFIGURATION" --quiet
 
   if [ -z "$PROJECT_ID" ]; then
     PROJECT_ID="$(gcloud config get-value core/project --quiet)"
@@ -202,7 +202,7 @@ function gcloudrig_delete_instance_template {
 }
 
 function gcloudrig_create_base_image {
-  if ! gcloud compute images describe "$IMAGE" --format "value(name)" &>/dev/null; then
+  if [ -z "$(gcloudrig_get_bootimage)" ]; then
     echo "Creating base image..."
     gcloud compute images create "$IMAGE" \
       --source-image-family "$IMAGEBASEFAMILY" \

--- a/globals.sh
+++ b/globals.sh
@@ -195,7 +195,7 @@ function gcloudrig_delete_instance_group {
 
 function gcloudrig_delete_instance_template {
   # if the instance template already exists, delete it
-  if ! [ -z "$(gcloud compute instance-templates list --filter "name=$INSTANCETEMPLATE region:($REGION)" --format "value(name)" --quiet)" ]; then
+  if ! [ -z "$(gcloud compute instance-templates list --filter "name=$INSTANCETEMPLATE" --format "value(name)" --quiet)" ]; then
     gcloud compute instance-templates delete "$INSTANCETEMPLATE" \
       --quiet
   fi

--- a/globals.sh
+++ b/globals.sh
@@ -273,7 +273,7 @@ function gcloudrig_games_disk_to_snapshot {
 
   # delete them
   for SNAP in "${SNAPSHOTS[@]}"; do
-    gcloud compute snapshots delete --quiet
+    gcloud compute snapshots delete "$SNAP" --quiet
   done
 
 }

--- a/globals.sh
+++ b/globals.sh
@@ -13,13 +13,13 @@ IMAGEBASEFAMILY="windows-2016"
 IMAGEBASEPROJECT="windows-cloud"
 
 # various resource and label names
-GAMESDISK="gcloudrig-test-games"
-GCRLABEL="gcloudrig-test"
-IMAGEFAMILY="gcloudrig-test"
-INSTANCEGROUP="gcloudrig-test-group"
-INSTANCENAME="gcloudrig-test"
-INSTANCETEMPLATE="gcloudrig-test-template"
-CONFIGURATION="gcloudrig-test"
+GAMESDISK="gcloudrig-games"
+GCRLABEL="gcloudrig"
+IMAGEFAMILY="gcloudrig"
+INSTANCEGROUP="gcloudrig-group"
+INSTANCENAME="gcloudrig"
+INSTANCETEMPLATE="gcloudrig-template"
+CONFIGURATION="gcloudrig"
 
 # override only if nessessary
 REGION=""
@@ -55,7 +55,7 @@ function init {
 
 function init_setup {
 
-  if [ -z "$(gcloud config configurations list --filter "name=$CONFIGURATION" --format "value(name)")" ]; then
+  if [ -z "$(gcloud config configurations list --filter "name=(gcloudrig)" --format "value(name)" --quiet)" ]; then
     gcloud config configurations create $CONFIGURATION --quiet
   fi
 

--- a/globals.sh
+++ b/globals.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 
-# gcloudrig/globals.sh
-
-# region and project?
-REGION="australia-southeast1"
-PROJECT_ID="gcloudrig"
+# region and project
+REGION=""
+PROJECT_ID=""
 
 # instance and boot disk type?
 INSTANCETYPE="n1-standard-8"
@@ -25,215 +23,262 @@ IMAGE="gcloudrig"
 INSTANCEGROUP="gcloudrig"
 INSTANCENAME="gcloudrig"
 INSTANCETEMPLATE="gcloudrig"
+CONFIGURATION="gcloudrig"
 
-# always run
+# sensible globals
 function init_globals {
-	
-	# config
-	gcloud config set project "$PROJECT_ID" \
-		--quiet
 
-	# set zones for this region
-	gcloudrig_set_zones
-	
+  PROJECT_ID="$(gcloud config get-value core/project --quiet)"
+  REGION="$(gcloud config get-value compute/region --quiet)"
+
+  # if we don't have a project id or region, bail and ask user to run "gcloud init"
+
+  if [ -z "$PROJECT_ID" ]; then
+    echo "Unable to read config for 'core/project'!"
+    echo
+    echo "Please run 'gcloud init' followed by './setup.sh' to re-initialize the existing configuration, [$CONFIGURATION]."
+    exit 1
+  fi
+
+  if [ -z "$REGION" ]; then
+    echo "Unable to read config for 'compute/region'!"
+    echo
+    echo "Please run './setup.sh' to re-initialize the existing configuration, [$CONFIGURATION]."
+  fi
+
+  # set zones for this region
+  gcloudrig_set_zones
+}
+
+# same as init_globals, but run during setup
+function init_setup {
+  # create/recreate configuration
+  echo "Creating configuration '$CONFIGURATION'"
+  gcloud config configurations create $CONFIGURATION --quiet &>/dev/null || echo -n
+  gcloud config configurations activate $CONFIGURATION --quiet
+
+  # check if default project is set;  if not, run 'gcloud init'
+  PROJECT_ID="$(gcloud config get-value core/project --quiet)"
+  if [ -z "$PROJECT_ID" ]; then
+    gcloud init
+    PROJECT_ID="$(gcloud config get-value core/project --quiet)"
+  fi
+
+  # check if compute api is enabled, if not enable it
+  COMPUTEAPI=$(gcloud services list --format "value(config.name)" --filter "config.name=compute.googleapis.com" --quiet)
+  if [ $COMPUTEAPI != "compute.googleapis.com" ]; then
+    echo "Enabling Compute API..."
+    gcloud services enable compute.googleapis.com
+  fi
+
+  # check if a default region is set, if not re-run 'gcloud init'
+  REGION="$(gcloud config get-value compute/region --quiet)"
+  if  [ -z "$REGION" ]; then
+    gcloud init --skip-diagnostics
+  else
+    echo "Re-run 'gcloud init' to select the default zone and region?"
+    select yn in "Yes" "No"; do
+        case $yn in
+            Yes ) gcloud init --skip-diagnostics; break;;
+            No ) echo "Skipping 'gcloud init' re-run!"; break;;
+        esac
+    done
+  fi
+
+  # now set the zones
+  gcloudrig_set_zones;
 }
 
 # Populate $ZONES with any zones that has the accelerator resources we're after in the $REGION we want
 function gcloudrig_set_zones {
-	ZONES=""
+  ZONES=""
 
-	local REGIONZONES=()
-	mapfile -d ";" -t REGIONZONES < <(gcloud compute regions describe "$REGION" \
-		--format="value(zones)")
+  local REGIONZONES=()
+  mapfile -d ";" -t REGIONZONES < <(gcloud compute regions describe "$REGION" \
+    --format="value(zones)")
 
-	local ACCELERATORZONES=()
-	mapfile -d ";" -t ACCELERATORZONES < <(gcloud compute accelerator-types list \
-		--filter "name=$ACCELERATORTYPE" \
-		--format "value(zone)")
+  local ACCELERATORZONES=()
+  mapfile -d ";" -t ACCELERATORZONES < <(gcloud compute accelerator-types list \
+    --filter "name=$ACCELERATORTYPE" \
+    --format "value(zone)")
 
-	for ZONEURI in "${REGIONZONES[@]}"; do
-		local ZONE=""
-		ZONE="$(basename -- "$ZONEURI")"
-		if [[ ${ACCELERATORZONES[*]} =~ $ZONE ]]; then
-			ZONES="${ZONES},${ZONE}"
-		fi;
-	done
+  for ZONEURI in "${REGIONZONES[@]}"; do
+    local ZONE=""
+    ZONE="$(basename -- "$ZONEURI")"
+    if [[ ${ACCELERATORZONES[*]} =~ $ZONE ]]; then
+      ZONES="${ZONES},${ZONE}"
+    fi;
+  done
 
-	ZONES="${ZONES:1}"
+  ZONES="${ZONES:1}"
 }
 
 # Get instance name from instance group
 function gcloudrig_get_instance_from_group {
-
-	local region="$1"
-	local instance_group="$2"
-	gcloud compute instance-groups list-instances "$instance_group" \
-	--region "$region" \
-	--format "value(instance)" \
-	--quiet
+  local instance_group="$1"
+  gcloud compute instance-groups list-instances "$instance_group" \
+  --format "value(instance)" \
+  --quiet
 
 }
 
 # Get instance zone from instance group
 function gcloudrig_get_instance_zone_from_group {
-
-	local region="$1"
-	local instance_group="$2"
-	gcloud compute instance-groups list-instances "$instance_group" \
-	--region "$region" \
-	--format "value(instance.scope().segment(0))" \
-	--quiet
+  local instance_group="$1"
+  gcloud compute instance-groups list-instances "$instance_group" \
+  --format "value(instance.scope().segment(0))" \
+  --quiet
 
 }
 
 # Get bootdisk from instance
 function gcloudrig_get_bootdisk_from_instance {
-
-	local zone="$1"
-	local instance="$2"
-	gcloud compute instances describe "$instance" \
-		--zone "$zone" \
-		--format "value(disks[0].source.basename())" \
-		--quiet
+  local zone="$1"
+  local instance="$2"
+  gcloud compute instances describe "$instance" \
+    --zone "$zone" \
+    --format "value(disks[0].source.basename())" \
+    --quiet
 
 }
 
 function wait_until_instance_group_is_stable {
-	timeout 300s gcloud compute instance-groups managed wait-until-stable "$INSTANCEGROUP" \
-		--region "$REGION" \
-		--quiet
+  timeout 120s gcloud compute instance-groups managed wait-until-stable "$INSTANCEGROUP" \
+    --quiet
 
-	err=$?
+  err=$?
 
-	if $err; then
-		gcloud logging read 'severity>=WARNING' \
-			--freshness 10m \
-			--format "table[box,title='-- Recent logs (10m) --'](timestamp,protoPayload.status.message)"
-		return $err
-	fi
+  if [ "$err" -gt "0" ]; then
+    gcloud logging read 'severity>=WARNING' \
+      --freshness 10m \
+      --format "table[box,title='-- Recent logs (10m) --'](timestamp,protoPayload.status.message)"
+    return $err
+  fi
 }
 
 # scale to 1 and wait, with retries every 5 minutes
 function gcloudrig_start {
+  echo "Starting gcloudrig..."
 
-	# scale to 1
-	gcloud compute instance-groups managed resize "$INSTANCEGROUP" \
-		--size "1" \
-		--region "$REGION" \
-		--format "value(currentActions)" \
-		--quiet
+  # scale to 1
+  gcloud compute instance-groups managed resize "$INSTANCEGROUP" \
+    --size "1" \
+    --format "value(currentActions)" \
+    --quiet &>/dev/null
 
-	# if it doesn't start in 5 minutes
-	while ! wait_until_instance_group_is_stable; do
+  # if it doesn't start in 5 minutes
+  while ! wait_until_instance_group_is_stable; do
 
-		# scale it back down
-		gcloud compute instance-groups managed resize "$INSTANCEGROUP" \
-			--size "0" \
-			--region "$REGION" \
-			--format "value(currentActions)" \
-			--quiet
+    # scale it back down
+    gcloud compute instance-groups managed resize "$INSTANCEGROUP" \
+      --size "0" \
+      --format "value(currentActions)" \
+      --quiet &>/dev/null
 
-		# wait
-		wait_until_instance_group_is_stable
+    # wait
+    wait_until_instance_group_is_stable
 
-		# and back up again (chance of being spawned in a different zone)
-		gcloud compute instance-groups managed resize "$INSTANCEGROUP" \
-			--size "1" \
-			--region "$REGION" \
-			--format "value(currentActions)" \
-			--quiet
-	done
+    # and back up again (chance of being spawned in a different zone)
+    gcloud compute instance-groups managed resize "$INSTANCEGROUP" \
+      --size "1" \
+      --format "value(currentActions)" \
+      --quiet &>/dev/null
+  done
 
-	# we have an instance!
-	INSTANCE="$(gcloudrig_get_instance_from_group "$REGION" "$INSTANCEGROUP")"
-	ZONE="$(gcloudrig_get_instance_zone_from_group "$REGION" "$INSTANCEGROUP")"
-	BOOTDISK="$(gcloudrig_get_bootdisk_from_instance "$ZONE" "$INSTANCE")"
+  # we have an instance!
+  INSTANCE="$(gcloudrig_get_instance_from_group "$INSTANCEGROUP")"
+  ZONE="$(gcloudrig_get_instance_zone_from_group "$INSTANCEGROUP")"
+  BOOTDISK="$(gcloudrig_get_bootdisk_from_instance "$ZONE" "$INSTANCE")"
 
 }
 
 # scale to 0 and wait
 function gcloudrig_stop {
+  echo "Stopping gcloudrig..."
 
-	INSTANCE="$(gcloudrig_get_instance_from_group "$REGION" "$INSTANCEGROUP")"
-	ZONE="$(gcloudrig_get_instance_zone_from_group "$REGION" "$INSTANCEGROUP")"
-	BOOTDISK="$(gcloudrig_get_bootdisk_from_instance "$ZONE" "$INSTANCE")"
+  INSTANCE="$(gcloudrig_get_instance_from_group "$INSTANCEGROUP")"
+  ZONE="$(gcloudrig_get_instance_zone_from_group "$INSTANCEGROUP")"
+  BOOTDISK="$(gcloudrig_get_bootdisk_from_instance "$ZONE" "$INSTANCE")"
 
-	gcloud compute instance-groups managed resize "$INSTANCEGROUP" \
-		--size "0" \
-		--region "$REGION" \
-		--quiet
+  gcloud compute instance-groups managed resize "$INSTANCEGROUP" \
+    --size "0" \
+    --format "value(currentActions)" \
+    --quiet &>/dev/null
 
-	wait_until_instance_group_is_stable
+  wait_until_instance_group_is_stable
 
 }
 
 # turn boot disk into an image
 function gcloudrig_boot_disk_to_image {
 
-	echo "Creating boot image, this may take some time..."
+  echo "Creating boot image, this may take some time..."
 
-	# delete existing boot image
-	gcloud compute images delete "$IMAGE" --quiet \
-		|| echo "assuming $IMAGE doesn't exist, continuing..."
+  # delete existing boot image
+  gcloud compute images delete "$IMAGE" --quiet &>/dev/null || echo
 
-	# create boot image from boot disk
-	gcloud compute images create "$IMAGE" \
-		--source-disk "$BOOTDISK" \
-		--source-disk-zone "$ZONE" \
-		--guest-os-features WINDOWS \
-		--labels "$GCRLABEL=true" \
-		--quiet
+  # create boot image from boot disk
+  gcloud compute images create "$IMAGE" \
+    --source-disk "$BOOTDISK" \
+    --source-disk-zone "$ZONE" \
+    --guest-os-features WINDOWS \
+    --labels "$GCRLABEL=true" \
+    --quiet
 
-	# delete boot disk
-	gcloud compute disks delete "$BOOTDISK" \
-		--zone "$ZONE" \
-		--quiet
+  # delete boot disk
+  gcloud compute disks delete "$BOOTDISK" \
+    --zone "$ZONE" \
+    --quiet
 
 }
 
 # turn games disk into a snapshot
 function gcloudrig_games_disk_to_snapshot {
 
-	# save games snapshot, but don't label it yet
-	GAMESSNAP="$GAMESDISK-$(mktemp --dry-run XXXXXX | tr '[:upper:]' '[:lower:]')-snap"
-	gcloud compute disks snapshot "$GAMESDISK" \
-		--snapshot-names "$GAMESSNAP" \
-		--zone "$ZONE" \
-		--guest-flush \
-		--quiet
+  echo "Snapshotting games disk..."
 
-	# find existing snapshots
-	local SNAPSHOTS=()
-	mapfile -t SNAPSHOTS < <(gcloud compute snapshots list \
-			--format "value(name)" \
-		--filter "labels.$GCRLABEL=true")
+  # save games snapshot, but don't label it yet
+  GAMESSNAP="$GAMESDISK-$(mktemp --dry-run XXXXXX | tr '[:upper:]' '[:lower:]')-snap"
+  gcloud compute disks snapshot "$GAMESDISK" \
+    --snapshot-names "$GAMESSNAP" \
+    --zone "$ZONE" \
+    --guest-flush \
+    --quiet
 
-	# remove the "latest=true" label from all existing gcloudrig snapshots
-	for SNAP in "${SNAPSHOTS[@]}"; do
-		LATEST="$(gcloud compute snapshots describe "$SNAP" \
-			--format "value(labels.latest)")"
-		if [ "$LATEST" = "true" ]; then
-			gcloud compute snapshots remove-labels "$SNAP" \
-				--labels "latest"
-		fi
-	done
+  # find existing snapshots
+  local SNAPSHOTS=()
+  mapfile -t SNAPSHOTS < <(gcloud compute snapshots list \
+      --format "value(name)" \
+    --filter "labels.$GCRLABEL=true")
 
-	# add labels to the latest snapshot
-	gcloud compute snapshots add-labels "$GAMESSNAP" \
-		--labels "latest=true,$GCRLABEL=true"
+  # remove the "latest=true" label from all existing gcloudrig snapshots
+  for SNAP in "${SNAPSHOTS[@]}"; do
+    LATEST="$(gcloud compute snapshots describe "$SNAP" \
+      --format "value(labels.latest)")"
+    if [ "$LATEST" = "true" ]; then
+      gcloud compute snapshots remove-labels "$SNAP" \
+        --labels "latest"
+    fi
+  done
 
-	# delete games disk
-	gcloud compute disks delete "$GAMESDISK" \
-		--zone "$ZONE" \
-		--quiet
+  # add labels to the latest snapshot
+  gcloud compute snapshots add-labels "$GAMESSNAP" \
+    --labels "latest=true,$GCRLABEL=true"
 
-	# get all the snapshots again, *except* the one labelled latest
-	mapfile -t SNAPSHOTS < <(gcloud compute snapshots list \
-			--format "value(name)" \
-		--filter "labels.$GCRLABEL=true NOT labels.latest=true")
+  # delete games disk
+  gcloud compute disks delete "$GAMESDISK" \
+    --zone "$ZONE" \
+    --quiet
 
-	# delete them
-	gcloud compute snapshots delete "${SNAPSHOTS[@]}"
+  # get all the snapshots again, *except* the one labelled latest
+  mapfile -t SNAPSHOTS < <(gcloud compute snapshots list \
+      --format "value(name)" \
+      --filter "labels.$GCRLABEL=true NOT labels.latest=true")
+
+  # delete them
+  for SNAP in "${SNAPSHOTS[@]}"; do
+    gcloud compute snapshots delete --quiet
+  done
 
 }
 
@@ -241,32 +286,31 @@ function gcloudrig_games_disk_to_snapshot {
 # no size/disk type specifified; gcloud will default to 500GB pd-standard when creating
 function gcloudrig_mount_games_disk {
 
-	# get latest games snapshot
-	GAMESSNAP="$(gcloud compute snapshots list \
-		--format "value(name)" \
-		--filter "labels.gcloudrig=true labels.latest=true")"
+  echo "Mounting games disk..."
 
-	# restore games snapshot
-	# or create a new games disk
-	# or just keep going and assume a games disk already exists
-	gcloud compute disks create "$GAMESDISK" \
-		--zone "$ZONE" \
-		--source-snapshot "$GAMESSNAP" \
-		--quiet \
-		--labels "$GCRLABEL=true" \
-		|| gcloud compute disks create "$GAMESDISK" \
-			--zone "$ZONE" \
-			--quiet \
-			--labels "$GCRLABEL=true" \
-			|| echo "assuming $GAMESDISK exists, continuing..."
+  # get latest games snapshot
+  GAMESSNAP="$(gcloud compute snapshots list \
+    --format "value(name)" \
+    --filter "labels.gcloudrig=true labels.latest=true")"
 
-	# attach games disk
-	gcloud compute instances attach-disk "$INSTANCE" \
-	--disk "$GAMESDISK" \
-	--zone "$ZONE" \
-	--quiet
+  # restore games snapshot
+  # or create a new games disk
+  # or just keep going and assume a games disk already exists
+  gcloud compute disks create "$GAMESDISK" \
+    --zone "$ZONE" \
+    --source-snapshot "$GAMESSNAP" \
+    --quiet \
+    --labels "$GCRLABEL=true" &>/dev/null \
+    || gcloud compute disks create "$GAMESDISK" \
+      --zone "$ZONE" \
+      --quiet \
+      --labels "$GCRLABEL=true" &>/dev/null \
+      || echo "assuming $GAMESDISK exists, continuing..."
+
+  # attach games disk
+  gcloud compute instances attach-disk "$INSTANCE" \
+  --disk "$GAMESDISK" \
+  --zone "$ZONE" \
+  --quiet &>/dev/null
 
 }
-
-# Fire! 
-init_globals;

--- a/reset-windows-password.sh
+++ b/reset-windows-password.sh
@@ -11,9 +11,9 @@ DIR="$( cd "$( dirname -- "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source "$DIR/globals.sh"
 init_globals;
 
-INSTANCE="$(gloudrig_get_instance_from_group "$REGION" "$INSTANCEGROUP")"
+INSTANCE="$(gcloudrig_get_instance_from_group "$INSTANCEGROUP")"
 
-ZONE="$(gcloudrig_get_instance_zone_from_group "$REGION" "$INSTANCEGROUP")"
+ZONE="$(gcloudrig_get_instance_zone_from_group "$INSTANCEGROUP")"
 
 # set/reset windows credentials
 gcloud compute reset-windows-password "$INSTANCE" \

--- a/reset-windows-password.sh
+++ b/reset-windows-password.sh
@@ -6,9 +6,10 @@ set -e
 # full path to script dir
 DIR="$( cd "$( dirname -- "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-# load globals 
+# load globals
 # shellcheck source=globals.sh
 source "$DIR/globals.sh"
+init_globals;
 
 INSTANCE="$(gloudrig_get_instance_from_group "$REGION" "$INSTANCEGROUP")"
 

--- a/reset-windows-password.sh
+++ b/reset-windows-password.sh
@@ -9,7 +9,7 @@ DIR="$( cd "$( dirname -- "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 # load globals
 # shellcheck source=globals.sh
 source "$DIR/globals.sh"
-init_globals;
+init;
 
 INSTANCE="$(gcloudrig_get_instance_from_group "$INSTANCEGROUP")"
 

--- a/scale-down.sh
+++ b/scale-down.sh
@@ -9,7 +9,7 @@ DIR="$( cd "$( dirname -- "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 # load globals
 # shellcheck source=globals.sh
 source "$DIR/globals.sh"
-init_globals;
+init;
 
 # shut it down
 gcloudrig_stop

--- a/scale-down.sh
+++ b/scale-down.sh
@@ -6,20 +6,18 @@ set -e
 # full path to script dir
 DIR="$( cd "$( dirname -- "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-# load globals 
+# load globals
 # shellcheck source=globals.sh
 source "$DIR/globals.sh"
+init_globals;
 
 # shut it down
-echo "Stopping gcloudrig"
 gcloudrig_stop
 
 # save boot image
-echo "Saving new boot image"
-gcloudrig_boot_disk_to_image & 
+gcloudrig_boot_disk_to_image &
 
 # save games snapshot
-echo "Snapshotting games disk"
-gcloudrig_games_disk_to_snapshot & 
+gcloudrig_games_disk_to_snapshot &
 
 wait

--- a/scale-down.sh
+++ b/scale-down.sh
@@ -3,6 +3,8 @@
 # exit on error
 set -e
 
+set -x
+
 # full path to script dir
 DIR="$( cd "$( dirname -- "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 

--- a/scale-down.sh
+++ b/scale-down.sh
@@ -3,8 +3,6 @@
 # exit on error
 set -e
 
-set -x
-
 # full path to script dir
 DIR="$( cd "$( dirname -- "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 

--- a/scale-up.sh
+++ b/scale-up.sh
@@ -9,7 +9,7 @@ DIR="$( cd "$( dirname -- "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 # load globals
 # shellcheck source=globals.sh
 source "$DIR/globals.sh"
-init_globals;
+init;
 
 # start it up
 gcloudrig_start

--- a/scale-up.sh
+++ b/scale-up.sh
@@ -6,14 +6,13 @@ set -e
 # full path to script dir
 DIR="$( cd "$( dirname -- "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-# load globals 
+# load globals
 # shellcheck source=globals.sh
 source "$DIR/globals.sh"
+init_globals;
 
 # start it up
-echo "Starting gcloudrig"
 gcloudrig_start
 
 # mount games disk
-echo "Mounting games disk"
 gcloudrig_mount_games_disk

--- a/setup.sh
+++ b/setup.sh
@@ -3,56 +3,24 @@
 # exit on error
 set -e
 
+set -x
+
 # full path to script dir
-DIR="$( cd "$( dirname -- "${BASH_SOURCE[0]}" )" &>/dev/null && pwd )"
+DIR="$( cd "$( dirname -- "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 # load globals
 # shellcheck source=globals.sh
 source "$DIR/globals.sh"
+init_setup # init;
 
-# init setup
-init_setup
+gcloudrig_delete_instance_group
 
-# if image doesn't already exist
-if ! gcloud compute images describe "$IMAGE" --format "value(name)" &>/dev/null; then
+gcloudrig_delete_instance_template
 
-  # create one from the base image
-  gcloud compute images create "$IMAGE" \
-    --source-image-family "$IMAGEBASEFAMILY" \
-    --source-image-project "$IMAGEBASEPROJECT" \
-    --guest-os-features "WINDOWS" \
-    --family "$IMAGEFAMILY" \
-    --labels "$GCRLABEL=true"
+gcloudrig_create_base_image
 
-fi
+gcloudrig_create_instance_template
 
-echo "Deleting existing instance group and template"
-gcloud compute instance-groups managed delete "$INSTANCEGROUP" --region "$REGION" --quiet &>/dev/null || echo
-gcloud compute instance-templates delete "$INSTANCETEMPLATE" --quiet &>/dev/null || echo
-
-# create/recreate actual instance template
-echo "Creating instance template $INSTANCETEMPLATE..."
-gcloud compute instance-templates create "$INSTANCETEMPLATE" \
-  --image "$IMAGE" \
-  --machine-type "$INSTANCETYPE" \
-  --accelerator "type=$ACCELERATORTYPE,count=$ACCELERATORCOUNT" \
-  --boot-disk-type "$BOOTTYPE" \
-  --maintenance-policy "TERMINATE" \
-  --no-boot-disk-auto-delete \
-  --no-restart-on-failure \
-  --labels "$GCRLABEL=true" \
-  --quiet &>/dev/null
-
-# create a managed instance group that covers all zones (GPUs tend to be oversubscribed in certain zones)
-# and give it the base instance template
-echo "Creating managed instance group '$INSTANCEGROUP'..."
-gcloud compute instance-groups managed create "$INSTANCEGROUP" \
-  --region "$REGION" \
-  --base-instance-name "$INSTANCENAME" \
-  --template "$INSTANCETEMPLATE" \
-  --size "0" \
-  --zones "$ZONES" \
-  --format "value(name)" \
-  --quiet &>/dev/null
+gcloudrig_create_instance_group
 
 echo "Done!  Run './scale-up.sh' to start your instance."

--- a/setup.sh
+++ b/setup.sh
@@ -4,96 +4,93 @@
 set -e
 
 # full path to script dir
-DIR="$( cd "$( dirname -- "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+DIR="$( cd "$( dirname -- "${BASH_SOURCE[0]}" )" &>/dev/null && pwd )"
 
-# load globals 
+# load globals
 # shellcheck source=globals.sh
 source "$DIR/globals.sh"
 
-# create/recreate base instance template
-echo "Creating instance template $INSTANCETEMPLATE-base using latest $IMAGEBASEFAMILY image..."
-gcloud beta compute instance-templates delete "${INSTANCETEMPLATE}-base" --quiet || echo
-gcloud beta compute instance-templates create "${INSTANCETEMPLATE}-base" \
-	--image-family "$IMAGEBASEFAMILY" \
-	--image-project "$IMAGEBASEPROJECT" \
-	--machine-type "$INSTANCETYPE" \
-	--accelerator "type=$ACCELERATORTYPE,count=$ACCELERATORCOUNT" \
-	--boot-disk-type "$BOOTTYPE" \
-	--maintenance-policy "TERMINATE" \
-	--no-boot-disk-auto-delete \
-	--no-restart-on-failure \
-	--labels "$GCRLABEL=true" \
-	--format "value(name)" \
-	--quiet
+# init setup
+init_setup
 
-# create/recreate actual instance template
-echo "Creating instance template $INSTANCETEMPLATE..."
-gcloud beta compute instance-templates delete "$INSTANCETEMPLATE" --quiet || echo
-gcloud beta compute instance-templates create "$INSTANCETEMPLATE" \
-	--image "$IMAGE" \
-	--machine-type "$INSTANCETYPE" \
-	--accelerator "type=$ACCELERATORTYPE,count=$ACCELERATORCOUNT" \
-	--boot-disk-type "$BOOTTYPE" \
-	--maintenance-policy "TERMINATE" \
-	--no-boot-disk-auto-delete \
-	--no-restart-on-failure \
-	--labels "$GCRLABEL=true" \
-	--quiet
+# create/recreate base instance template
+echo
+echo "Creating instance template '$INSTANCETEMPLATE-base' using latest '$IMAGEBASEFAMILY' image..."
+gcloud beta compute instance-templates delete "${INSTANCETEMPLATE}-base" --quiet &>/dev/null || echo
+gcloud beta compute instance-templates create "${INSTANCETEMPLATE}-base" \
+  --image-family "$IMAGEBASEFAMILY" \
+  --image-project "$IMAGEBASEPROJECT" \
+  --machine-type "$INSTANCETYPE" \
+  --accelerator "type=$ACCELERATORTYPE,count=$ACCELERATORCOUNT" \
+  --boot-disk-type "$BOOTTYPE" \
+  --maintenance-policy "TERMINATE" \
+  --no-boot-disk-auto-delete \
+  --no-restart-on-failure \
+  --labels "$GCRLABEL=true" \
+  --format "value(name)" \
+  --quiet &>/dev/null
 
 # create a managed instance group that covers all zones (GPUs tend to be oversubscribed in certain zones)
 # and give it the base instance template
-echo "Creating managed instance group $INSTANCEGROUP..."
-gcloud beta compute instance-groups managed delete "$INSTANCEGROUP" --quiet \
-	--region "$REGION" \
-	|| echo
+echo "Creating managed instance group '$INSTANCEGROUP'..."
+gcloud beta compute instance-groups managed delete "$INSTANCEGROUP" --quiet &>/dev/null || echo
 gcloud beta compute instance-groups managed create "$INSTANCEGROUP" \
-	--base-instance-name "$INSTANCENAME" \
-	--template "${INSTANCETEMPLATE}-base" \
-	--size "0" \
-	--region "$REGION" \
-	--zones "$ZONES" \
-	--format "value(name)" \
-	--quiet
+  --base-instance-name "$INSTANCENAME" \
+  --template "${INSTANCETEMPLATE}-base" \
+  --size "0" \
+  --zones "$ZONES" \
+  --format "value(name)" \
+  --quiet
 
 # run first-boot things, only if an image doesn't already exist
-if ! gcloud compute images describe "$IMAGE" --format "value(name)"; then
+if ! gcloud compute images describe "$IMAGE" --format "value(name)" &>/dev/null; then
 
-	# turn it on
-	echo "Starting gcloudrig..."
-	gcloudrig_start
+  # turn it on
+  gcloudrig_start
 
-	# add extra volume
-	echo "Mounting games disk..."
-	gcloudrig_mount_games_disk
+  # add extra volume
+  gcloudrig_mount_games_disk
 
-	# wait for 60 seconds.  
-	# in future, this is where we should poll a URL or wait for a pub/sub to let us know software installation is complete.
-	echo "Waiting 60 seconds for instance to settle..."
-	sleep "60"
+  # wait for 60 seconds.
+  # in future, this is where we should poll a URL or wait for a pub/sub to let us know software installation is complete.
+  echo "Waiting 60 seconds for instance to settle..."
+  sleep "60"
 
-	# shut it down
-	echo "Stopping gcloudrig..."
-	gcloudrig_stop
+  # shut it down
+  gcloudrig_stop
 
-	# save boot image
-	echo "Saving new boot image..."
-	gcloudrig_boot_disk_to_image
+  # save boot image
+  gcloudrig_boot_disk_to_image &
 
-	# save games snapshot
-	echo "Snapshotting games disk..."
-	gcloudrig_games_disk_to_snapshot
+  # save games snapshot
+  gcloudrig_games_disk_to_snapshot &
+
+  wait
 
 fi
+
+# create/recreate actual instance template
+echo "Creating instance template $INSTANCETEMPLATE..."
+gcloud beta compute instance-templates delete "$INSTANCETEMPLATE" --quiet &>/dev/null || echo
+gcloud beta compute instance-templates create "$INSTANCETEMPLATE" \
+  --image "$IMAGE" \
+  --machine-type "$INSTANCETYPE" \
+  --accelerator "type=$ACCELERATORTYPE,count=$ACCELERATORCOUNT" \
+  --boot-disk-type "$BOOTTYPE" \
+  --maintenance-policy "TERMINATE" \
+  --no-boot-disk-auto-delete \
+  --no-restart-on-failure \
+  --labels "$GCRLABEL=true" \
+  --quiet &>/dev/null
 
 # point managed instance group at new template
 echo "Tidying up..."
 gcloud compute instance-groups managed set-instance-template "$INSTANCEGROUP" \
-	--template "$INSTANCETEMPLATE" \
-	--region "$REGION" \
-	--quiet
+  --template "$INSTANCETEMPLATE" \
+  --quiet
 
 # delete base template
 gcloud compute instance-templates delete "${INSTANCETEMPLATE}-base" \
-	--quiet
+  --quiet
 
 echo "Done!"

--- a/setup.sh
+++ b/setup.sh
@@ -13,65 +13,22 @@ source "$DIR/globals.sh"
 # init setup
 init_setup
 
-# create/recreate base instance template
-echo
-echo "Creating instance template '$INSTANCETEMPLATE-base' using latest '$IMAGEBASEFAMILY' image..."
-gcloud beta compute instance-templates delete "${INSTANCETEMPLATE}-base" --quiet &>/dev/null || echo
-gcloud beta compute instance-templates create "${INSTANCETEMPLATE}-base" \
-  --image-family "$IMAGEBASEFAMILY" \
-  --image-project "$IMAGEBASEPROJECT" \
-  --machine-type "$INSTANCETYPE" \
-  --accelerator "type=$ACCELERATORTYPE,count=$ACCELERATORCOUNT" \
-  --boot-disk-type "$BOOTTYPE" \
-  --maintenance-policy "TERMINATE" \
-  --no-boot-disk-auto-delete \
-  --no-restart-on-failure \
-  --labels "$GCRLABEL=true" \
-  --format "value(name)" \
-  --quiet &>/dev/null
-
-# create a managed instance group that covers all zones (GPUs tend to be oversubscribed in certain zones)
-# and give it the base instance template
-echo "Creating managed instance group '$INSTANCEGROUP'..."
-gcloud beta compute instance-groups managed delete "$INSTANCEGROUP" --quiet &>/dev/null || echo
-gcloud beta compute instance-groups managed create "$INSTANCEGROUP" \
-  --base-instance-name "$INSTANCENAME" \
-  --template "${INSTANCETEMPLATE}-base" \
-  --size "0" \
-  --zones "$ZONES" \
-  --format "value(name)" \
-  --quiet
-
-# run first-boot things, only if an image doesn't already exist
+# if image doesn't already exist
 if ! gcloud compute images describe "$IMAGE" --format "value(name)" &>/dev/null; then
 
-  # turn it on
-  gcloudrig_start
-
-  # add extra volume
-  gcloudrig_mount_games_disk
-
-  # wait for 60 seconds.
-  # in future, this is where we should poll a URL or wait for a pub/sub to let us know software installation is complete.
-  echo "Waiting 60 seconds for instance to settle..."
-  sleep "60"
-
-  # shut it down
-  gcloudrig_stop
-
-  # save boot image
-  gcloudrig_boot_disk_to_image &
-
-  # save games snapshot
-  gcloudrig_games_disk_to_snapshot &
-
-  wait
+  # create one from the base image
+  gcloud compute images create "$IMAGE" \
+    --source-image-family "$IMAGEBASEFAMILY" \
+    --source-image-project "$IMAGEBASEPROJECT"
 
 fi
 
+echo "Deleting existing instance group and template"
+gcloud beta compute instance-groups managed delete "$INSTANCEGROUP" --region "$REGION" --quiet &>/dev/null || echo
+gcloud beta compute instance-templates delete "$INSTANCETEMPLATE" --quiet &>/dev/null || echo
+
 # create/recreate actual instance template
 echo "Creating instance template $INSTANCETEMPLATE..."
-gcloud beta compute instance-templates delete "$INSTANCETEMPLATE" --quiet &>/dev/null || echo
 gcloud beta compute instance-templates create "$INSTANCETEMPLATE" \
   --image "$IMAGE" \
   --machine-type "$INSTANCETYPE" \
@@ -83,14 +40,16 @@ gcloud beta compute instance-templates create "$INSTANCETEMPLATE" \
   --labels "$GCRLABEL=true" \
   --quiet &>/dev/null
 
-# point managed instance group at new template
-echo "Tidying up..."
-gcloud compute instance-groups managed set-instance-template "$INSTANCEGROUP" \
+# create a managed instance group that covers all zones (GPUs tend to be oversubscribed in certain zones)
+# and give it the base instance template
+echo "Creating managed instance group '$INSTANCEGROUP'..."
+gcloud beta compute instance-groups managed create "$INSTANCEGROUP" \
+  --region "$REGION" \
+  --base-instance-name "$INSTANCENAME" \
   --template "$INSTANCETEMPLATE" \
-  --quiet
+  --size "0" \
+  --zones "$ZONES" \
+  --format "value(name)" \
+  --quiet &>/dev/null
 
-# delete base template
-gcloud compute instance-templates delete "${INSTANCETEMPLATE}-base" \
-  --quiet
-
-echo "Done!"
+echo "Done!  Run './scale-up.sh' to start your instance."

--- a/setup.sh
+++ b/setup.sh
@@ -19,17 +19,20 @@ if ! gcloud compute images describe "$IMAGE" --format "value(name)" &>/dev/null;
   # create one from the base image
   gcloud compute images create "$IMAGE" \
     --source-image-family "$IMAGEBASEFAMILY" \
-    --source-image-project "$IMAGEBASEPROJECT"
+    --source-image-project "$IMAGEBASEPROJECT" \
+    --guest-os-features "WINDOWS" \
+    --family "$IMAGEFAMILY" \
+    --labels "$GCRLABEL=true"
 
 fi
 
 echo "Deleting existing instance group and template"
-gcloud beta compute instance-groups managed delete "$INSTANCEGROUP" --region "$REGION" --quiet &>/dev/null || echo
-gcloud beta compute instance-templates delete "$INSTANCETEMPLATE" --quiet &>/dev/null || echo
+gcloud compute instance-groups managed delete "$INSTANCEGROUP" --region "$REGION" --quiet &>/dev/null || echo
+gcloud compute instance-templates delete "$INSTANCETEMPLATE" --quiet &>/dev/null || echo
 
 # create/recreate actual instance template
 echo "Creating instance template $INSTANCETEMPLATE..."
-gcloud beta compute instance-templates create "$INSTANCETEMPLATE" \
+gcloud compute instance-templates create "$INSTANCETEMPLATE" \
   --image "$IMAGE" \
   --machine-type "$INSTANCETYPE" \
   --accelerator "type=$ACCELERATORTYPE,count=$ACCELERATORCOUNT" \
@@ -43,7 +46,7 @@ gcloud beta compute instance-templates create "$INSTANCETEMPLATE" \
 # create a managed instance group that covers all zones (GPUs tend to be oversubscribed in certain zones)
 # and give it the base instance template
 echo "Creating managed instance group '$INSTANCEGROUP'..."
-gcloud beta compute instance-groups managed create "$INSTANCEGROUP" \
+gcloud compute instance-groups managed create "$INSTANCEGROUP" \
   --region "$REGION" \
   --base-instance-name "$INSTANCENAME" \
   --template "$INSTANCETEMPLATE" \


### PR DESCRIPTION
-  No more need to edit variables in globals.sh; use `gcloud init` instead
-  Tidied up console output to be a little less of an eyesore
-  Updated readme

Outstanding:
-  Need a way to persist `gcloud config configurations` in cloudshell, not sure why they don't persist between shells
-  #12 Support for preemptible instance templates