### PR TITLE
add check for default zone having GPUs

### DIFF
--- a/destroy.sh
+++ b/destroy.sh
@@ -2,6 +2,7 @@
 
 # exit on error
 set -e
+[ -n "$GCLOUDRIG_DEBUG" ] && set -x
 
 # full path to script dir
 DIR="$( cd "$( dirname -- "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"

--- a/globals.sh
+++ b/globals.sh
@@ -288,22 +288,19 @@ function gcloudrig_update_instance_group {
 
 # deletes existing instance group and all templates
 function gcloudrig_delete_instance_group {
-  if ! [ -z "$(gcloud compute instance-groups list --filter "name=$INSTANCEGROUP region:($REGION)" --format "value(name)" --quiet)" ]; then
+  if [ -n "$(gcloud compute instance-groups list --filter "name=$INSTANCEGROUP region:($REGION)" --format "value(name)" --quiet)" ]; then
     gcloud compute instance-groups managed delete "$INSTANCEGROUP" \
       --region "$REGION" \
       --quiet
   fi
-
 
   # tidy up - delete all other templates
   local templates=()
   mapfile -t templates < <(gcloud compute instance-templates list \
     --format "value(name)" \
     --filter "properties.labels.gcloudrig=true")
-  for templates in ${templates[*]}; do
-    if ! [ "$newtemplate" == "$template" ]; then
-      gcloud compute instance-templates delete "$template" --quiet
-    fi
+  for template in "${templates[@]}"; do
+    gcloud compute instance-templates delete "$template" --quiet
   done
 }
 

--- a/globals.sh
+++ b/globals.sh
@@ -204,7 +204,7 @@ function gcloudrig_get_bootimage {
 # Get zones with accelerators in region $1
 # if $1 is not specified, all regions
 function gcloudrig_get_accelerator_zones {
-  local region="${1:-'*'}"
+  local region="${1:-*}"
   gcloud compute accelerator-types list \
     --filter "zone:$region AND name=$ACCELERATORTYPE" \
     --format "value(zone)"

--- a/globals.sh
+++ b/globals.sh
@@ -60,7 +60,7 @@ function init_setup {
 
   if [ -n "$REGION" -a -n "$PROJECT_ID" ] ; then
     # settings at the top of this file
-    enable_required_glcoud_apis
+    enable_required_gcloud_apis
   else
     # use gcloud config configurations
     gcloud_config_setup
@@ -127,7 +127,7 @@ function gcloud_config_setup {
   fi
 
   # this is required before we can check for regions with GPUs
-  enable_required_glcoud_apis
+  enable_required_gcloud_apis
 
   # check default region is set, if not select one from regions with accelerators
   REGION="$(gcloud config get-value compute/region 2>/dev/null)"
@@ -157,7 +157,7 @@ function gcloud_projects_create {
   exit 1
 }
 
-function enable_required_glcoud_apis {
+function enable_required_gcloud_apis {
   # check if compute api is enabled, if not enable it
   local COMPUTEAPI=$(gcloud services list --format "value(config.name)" --filter "config.name=compute.googleapis.com" --quiet)
   if [ "$COMPUTEAPI" != "compute.googleapis.com" ]; then

--- a/globals.sh
+++ b/globals.sh
@@ -56,17 +56,20 @@ function init_gcloudrig {
 
 function wrap_gcloud_init {
 
-  cat <<EOF
+  local ACCELERATORZONES="$(gcloudrig_get_accelerator_zones 2> /dev/null)"
+  if [ -n "$ACCELERATORZONES" ] ; then
+    cat <<EOF
 
 ################################################################################
 #  About to run 'gcloud init'.
 #  When prompted for a zone choose one with $ACCELERATORTYPE GPUs
 #  from this list:
-$(gcloudrig_get_accelerator_zones)
+$ACCELERATORZONES
 ################################################################################
 
 
 EOF
+  fi
 
   gcloud init "$@"
   PROJECT_ID="$(gcloud config get-value core/project --quiet)"

--- a/reset-windows-password.sh
+++ b/reset-windows-password.sh
@@ -2,6 +2,7 @@
 
 # exit on error
 set -e
+[ -n "$GCLOUDRIG_DEBUG" ] && set -x
 
 # full path to script dir
 DIR="$( cd "$( dirname -- "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"

--- a/scale-down.sh
+++ b/scale-down.sh
@@ -2,6 +2,7 @@
 
 # exit on error
 set -e
+[ -n "$GCLOUDRIG_DEBUG" ] && set -x
 
 # full path to script dir
 DIR="$( cd "$( dirname -- "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"

--- a/scale-up.sh
+++ b/scale-up.sh
@@ -2,6 +2,7 @@
 
 # exit on error
 set -e
+[ -n "$GCLOUDRIG_DEBUG" ] && set -x
 
 # full path to script dir
 DIR="$( cd "$( dirname -- "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"

--- a/setup.sh
+++ b/setup.sh
@@ -2,8 +2,7 @@
 
 # exit on error
 set -e
-
-set -x
+[ -n "$GCLOUDRIG_DEBUG" ] && set -x
 
 # full path to script dir
 DIR="$( cd "$( dirname -- "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"


### PR DESCRIPTION
potential fix for #23 

there's no point in gcloudrig to have a default zone that doesn't have GPUs, so refactor a bit to check.
add error messages to help guide the user to choose a valid zone.