### PR TITLE
add Chocolatey as an optional install

### DIFF
--- a/gcloudrig.psm1
+++ b/gcloudrig.psm1
@@ -18,6 +18,7 @@ workflow Install-gCloudRig {
   #    "ZeroTierNetwork"   = $null
   #    "InstallBattlenet"  = $false
   #    "InstallSteam"      = $false
+  #    "InstallChocolatey" = $false
   #  }
 
   Set-SetupState "installing"
@@ -149,6 +150,9 @@ Function Install-OptionalSoftware {
   }
   If(Get-HashValue $InstallOptions "InstallSteam" $false) {
     Install-Steam 
+  }
+  If(Get-HashValue $InstallOptions "InstallChocolatey" $false) {
+    Install-Chocolatey 
   }
 
 }
@@ -397,6 +401,14 @@ Function Install-Steam {
 -Command "Stop-Process -Name "Steam" -Force -ErrorAction SilentlyContinue ; & 'C:\Program Files (x86)\Steam\Steam.exe'"
 '@
   Register-ScheduledTask -Action $action -Description "called by SSM to restart steam. necessary to avoid being stuck in Session 0 desktop." -Force -TaskName "gCloudRig Restart Steam" -TaskPath "\"
+}
+
+Function Install-Chocolatey {
+  Write-Status "Install Chocolatey..."
+  Save-UrlToFile -URL "https://chocolatey.org/install.ps1" -File "c:\gcloudrig\downloads\chocolatey-install.ps1"
+  If(Test-Path "c:\gcloudrig\downloads\chocolatey-install.ps1") {
+    & "c:\gcloudrig\downloads\chocolatey-install.ps1" 2>&1  | Out-File -Append "c:\gcloudrig\installer.txt"
+  }
 }
 
 Function Install-VBAudioCable {

--- a/globals.sh
+++ b/globals.sh
@@ -34,6 +34,7 @@ SETUPOPTIONS[ZeroTierNetwork]=""
 SETUPOPTIONS[VideoMode]="1920x1080"
 SETUPOPTIONS[InstallSteam]="false"
 SETUPOPTIONS[InstallBattlenet]="false"
+SETUPOPTIONS[InstallChocolatey]="false"
 
 ########
 # INIT #


### PR DESCRIPTION
for #29, adding this as an optional install.  

It seems like a lot of Chocolatey packages are poorly maintained.  ex. The parsec-cloud package is broken, I reported it almost a month ago and it hasn't been fixed.