### PR TITLE
`--snapshot-location` to `--storage-location`

### DIFF
--- a/globals.sh
+++ b/globals.sh
@@ -745,7 +745,7 @@ function gcloudrig_games_disk_to_snapshot {
   gcloud compute disks snapshot "$GAMESDISK" \
     --snapshot-names "$newsnapshot" \
     --zone "$ZONE" \
-    --snapshot-location "$REGION" \
+    --storage-location "$REGION" \
     --guest-flush \
     --quiet &>/dev/null
 


### PR DESCRIPTION
I noticed that snapshots for the games disk do not work. 
When running manually this is suggested by the `gcloud` cli.
```
$ gcloud compute disks snapshot gcloudrig-games --snapshot-names gcloudrig-games-20190830163104 --zone europe-west4-c --snapshot-location europe-west4 --guest-flush
ERROR: (gcloud.compute.disks.snapshot) unrecognized arguments:
  --snapshot-location (did you mean '--storage-location'?)
  europe-west4
  To search the help text of gcloud commands, run:
  gcloud help -- SEARCH_TERMS
```

And it seems to work.