### PR TITLE
Use cloudpingtest.com instead of gcping.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Note: you will require a Google Cloud project with an active billing account to 
    Created [gcloudrig].
    Activated [gcloudrig].
 
-   You can use http://gcping.com to find the closest region
+   You can use https://cloudpingtest.com/gcp to find the closest region
    
    Select a region to use:
    1) asia-southeast1          5) us-central1

--- a/globals.sh
+++ b/globals.sh
@@ -335,7 +335,7 @@ function gcloudrig_select_region {
   local ACCELERATORREGIONS="$(gcloudrig_get_accelerator_zones | sed -ne 's/-[a-z]$//p' | sort -u)"
   if [ -n "$ACCELERATORREGIONS" ] ; then
     echo
-    echo "You can use http://gcping.com to find the closest region"
+    echo "You can use https://cloudpingtest.com/gcp to find the closest region"
     echo
     echo "Select a region to use:"
     select REGION in $ACCELERATORREGIONS ; do


### PR DESCRIPTION
[https://cloudpingtest.com/gcp](cloudpingtest) has more regions, and, in my experience, I had some issues with GCPing being incredibly slow, while cloudpingtest never was. Also, it does multiple tests in a row (until you stop it), displaying the mean, median, min, and max, useful information that GCPing does not provide.